### PR TITLE
Multiaddress support

### DIFF
--- a/substrate-client/src/main/java/io/nodle/substratesdk/SubstrateApi.kt
+++ b/substrate-client/src/main/java/io/nodle/substratesdk/SubstrateApi.kt
@@ -8,6 +8,7 @@ import io.nodle.substratesdk.rpc.PaymentQueryInfo
 import io.nodle.substratesdk.rpc.StateGetStorage
 import io.nodle.substratesdk.rpc.SubstrateProvider
 import io.nodle.substratesdk.scale.*
+import io.nodle.substratesdk.scale.v1.readAccountInfoV1
 import io.nodle.substratesdk.types.*
 import io.nodle.substratesdk.utils.*
 import io.reactivex.rxjava3.core.Single
@@ -64,9 +65,9 @@ fun Wallet.signTx(
                 BigInteger.ZERO,
                 transactionVersion
             )
-            val signature = privateKey.signMsg(payload.toU8a())
+            val signature = privateKey.signMsg(payload.toU8a(provider))
             val extrinsicSignature = ExtrinsicSignature(
-                privateKey.generatePublicKey(),
+                AccountIDAddress(privateKey.generatePublicKey()),
                 ExtrinsicEd25519Signature(signature),
                 era,
                 sourceWalletInfo.nonce.toLong(),
@@ -82,12 +83,12 @@ fun Wallet.signTx(
 
 fun Extrinsic.estimateFee(provider: SubstrateProvider): Single<BigInteger> {
     return provider.rpc
-        .send<JSONObject>(PaymentQueryInfo("0x" + this.toU8a().toHex()))
+        .send<JSONObject>(PaymentQueryInfo("0x" + toU8a(provider).toHex()))
         .map { it.getString("partialFee").toBigInteger() }
 }
 
 fun Extrinsic.send(provider: SubstrateProvider): Single<String> {
-    return provider.rpc.send(AuthorSubmitExtrinsic("0x" + this.toU8a().toHex()))
+    return provider.rpc.send(AuthorSubmitExtrinsic("0x" + toU8a(provider).toHex()))
 }
 
 @ExperimentalUnsignedTypes

--- a/substrate-client/src/main/java/io/nodle/substratesdk/account/Account.kt
+++ b/substrate-client/src/main/java/io/nodle/substratesdk/account/Account.kt
@@ -1,5 +1,7 @@
 package io.nodle.substratesdk.account
 
+import io.nodle.substratesdk.types.AccountIDAddress
+import io.nodle.substratesdk.types.MultiAddress
 import io.nodle.substratesdk.utils.hexToBa
 import io.nodle.substratesdk.utils.toHex
 import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters
@@ -42,6 +44,10 @@ open class Account() {
             throw InvalidAccount()
         }
         ss58 = accountBa.toSS58()
+    }
+
+    fun toMultiAddress(): MultiAddress {
+        return AccountIDAddress(ss58.ss58ToBa())
     }
 
     fun toSS58(): String {

--- a/substrate-client/src/main/java/io/nodle/substratesdk/scale/AccountInfo+Parser.kt
+++ b/substrate-client/src/main/java/io/nodle/substratesdk/scale/AccountInfo+Parser.kt
@@ -9,6 +9,7 @@ import java.nio.ByteOrder
  * @author Lucien Loiseau on 30/07/20.
  */
 
+class ScaleEncoderException(msg: String?) : Exception(msg)
 
 // with the release of Substrate 2.0, the refCount is represented as u32 instead of u8
 // Substrate v2.0.0 https://github.com/paritytech/substrate/releases/tag/v2.0.0
@@ -17,19 +18,6 @@ fun ByteBuffer.readAccountInfoV12(): AccountInfo {
     return AccountInfo(
         readU32(),
         readU32(),
-        AccountData(
-            readU128(),
-            readU128(),
-            readU128(),
-            readU128()
-        )
-    )
-}
-
-fun ByteBuffer.readAccountInfoV1(): AccountInfo {
-    return AccountInfo(
-        readU32(),
-        readU8().toUInt(),
         AccountData(
             readU128(),
             readU128(),

--- a/substrate-client/src/main/java/io/nodle/substratesdk/scale/BasicType+Encoder.kt
+++ b/substrate-client/src/main/java/io/nodle/substratesdk/scale/BasicType+Encoder.kt
@@ -10,6 +10,12 @@ import kotlin.math.pow
 /**
  * @author Lucien Loiseau on 14/08/20.
  */
+
+fun Byte.toU8a(): ByteArray = ByteBuffer.allocate(1)
+    .order(ByteOrder.LITTLE_ENDIAN)
+    .put(this)
+    .array()
+
 fun Short.toU8a(): ByteArray = ByteBuffer.allocate(2)
     .order(ByteOrder.LITTLE_ENDIAN)
     .putShort(this)

--- a/substrate-client/src/main/java/io/nodle/substratesdk/scale/BasicType+Encoder.kt
+++ b/substrate-client/src/main/java/io/nodle/substratesdk/scale/BasicType+Encoder.kt
@@ -72,6 +72,10 @@ fun String.toU8a(): ByteArray {
     return buf.size.toLong().toCompactU8a() + buf
 }
 
+fun ByteArray.toU8a(): ByteArray {
+    return this.size.toLong().toCompactU8a() + this
+}
+
 fun <T> List<T>.toU8a(toU8a: T.() -> ByteArray): ByteArray {
     var buf = ByteArray(0)
     forEach {

--- a/substrate-client/src/main/java/io/nodle/substratesdk/scale/Call+Encoder.kt
+++ b/substrate-client/src/main/java/io/nodle/substratesdk/scale/Call+Encoder.kt
@@ -14,7 +14,7 @@ fun ExtrinsicCall.toU8a(): ByteArray {
 
 fun TransferCall.toU8a(): ByteArray {
     return byteArrayOf(moduleIndex.toByte(), callIndex.toByte()) +
-            byteArrayOf(0xff.toByte()) +
-            destAccount.toU8a() +
+            destAccount.toMultiAddress().toU8a() +
             amount.toCompactU8a()
 }
+

--- a/substrate-client/src/main/java/io/nodle/substratesdk/scale/MultiAddress+Encoder.kt
+++ b/substrate-client/src/main/java/io/nodle/substratesdk/scale/MultiAddress+Encoder.kt
@@ -7,7 +7,7 @@ import io.nodle.substratesdk.types.*
  */
 
 fun MultiAddress.toU8a(): ByteArray {
-    return byteArrayOf(type.id.toByte()) +
+    return type.id.toByte().toU8a() +
             when (type) {
                 AddressType.AccountID -> (this as AccountIDAddress).pubkey
                 AddressType.Raw -> (this as RawAddress).bytes.toU8a()

--- a/substrate-client/src/main/java/io/nodle/substratesdk/scale/MultiAddress+Encoder.kt
+++ b/substrate-client/src/main/java/io/nodle/substratesdk/scale/MultiAddress+Encoder.kt
@@ -1,0 +1,18 @@
+package io.nodle.substratesdk.scale
+
+import io.nodle.substratesdk.types.*
+
+/**
+ * @author Lucien Loiseau on 09/04/21.
+ */
+
+fun MultiAddress.toU8a(): ByteArray {
+    return byteArrayOf(type.id.toByte()) +
+            when (type) {
+                AddressType.AccountID -> (this as AccountIDAddress).pubkey
+                AddressType.Raw -> (this as RawAddress).bytes.toU8a()
+                AddressType.Address20 -> (this as Address20).bytes
+                AddressType.Address32 -> (this as Address32).bytes
+                else -> throw ScaleParserException("unsupported multiaddress type: ${type.name}")
+            }
+}

--- a/substrate-client/src/main/java/io/nodle/substratesdk/scale/MultiAddress+Parser.kt
+++ b/substrate-client/src/main/java/io/nodle/substratesdk/scale/MultiAddress+Parser.kt
@@ -1,0 +1,30 @@
+package io.nodle.substratesdk.scale
+
+import io.nodle.substratesdk.types.*
+import java.nio.ByteBuffer
+
+/**
+ * @author Lucien Loiseau on 09/04/21.
+ */
+
+@ExperimentalUnsignedTypes
+fun ByteBuffer.readMultiAddress(): MultiAddress =
+    when (val type = this.readU8().toInt()) {
+        AddressType.AccountID.id -> {
+            val ba = ByteArray(32)
+            get(ba)
+            AccountIDAddress(ba)
+        }
+        AddressType.Raw.id -> RawAddress(readByteArray())
+        AddressType.Address20.id -> {
+            val ba = ByteArray(20)
+            get(ba)
+            Address20(ba)
+        }
+        AddressType.Address32.id -> {
+            val ba = ByteArray(32)
+            get(ba)
+            Address32(ba)
+        }
+        else -> throw ScaleParserException("unsupported multiaddress type: ${type}")
+    }

--- a/substrate-client/src/main/java/io/nodle/substratesdk/scale/v1/AccountInfo+Parser.kt
+++ b/substrate-client/src/main/java/io/nodle/substratesdk/scale/v1/AccountInfo+Parser.kt
@@ -1,0 +1,26 @@
+package io.nodle.substratesdk.scale.v1
+
+import io.nodle.substratesdk.scale.readU128
+import io.nodle.substratesdk.scale.readU32
+import io.nodle.substratesdk.scale.readU8
+import io.nodle.substratesdk.types.AccountData
+import io.nodle.substratesdk.types.AccountInfo
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * @author Lucien Loiseau on 09/04/21.
+ */
+
+fun ByteBuffer.readAccountInfoV1(): AccountInfo {
+    return AccountInfo(
+        readU32(),
+        readU8().toUInt(),
+        AccountData(
+            readU128(),
+            readU128(),
+            readU128(),
+            readU128()
+        )
+    )
+}

--- a/substrate-client/src/main/java/io/nodle/substratesdk/scale/v2/Call+Encoder.kt
+++ b/substrate-client/src/main/java/io/nodle/substratesdk/scale/v2/Call+Encoder.kt
@@ -1,0 +1,21 @@
+package io.nodle.substratesdk.scale.v2
+
+import io.nodle.substratesdk.scale.toCompactU8a
+import io.nodle.substratesdk.types.*
+
+/**
+ * @author Lucien Loiseau on 30/07/20.
+ */
+
+fun ExtrinsicCall.toU8aV2(): ByteArray {
+    return (this as? TransferCall)
+        ?.toU8aV2()
+        ?: byteArrayOf()
+}
+
+fun TransferCall.toU8aV2(): ByteArray {
+    return byteArrayOf(moduleIndex.toByte(), callIndex.toByte()) +
+            byteArrayOf(0xff.toByte()) +
+            destAccount.toU8a() +
+            amount.toCompactU8a()
+}

--- a/substrate-client/src/main/java/io/nodle/substratesdk/scale/v2/Extrinsic+Encoder.kt
+++ b/substrate-client/src/main/java/io/nodle/substratesdk/scale/v2/Extrinsic+Encoder.kt
@@ -1,0 +1,35 @@
+package io.nodle.substratesdk.scale.v2
+
+import io.nodle.substratesdk.scale.ScaleEncoderException
+import io.nodle.substratesdk.scale.toCompactU8a
+import io.nodle.substratesdk.scale.toU8a
+import io.nodle.substratesdk.types.*
+
+fun Extrinsic.toU8aV2(): ByteArray {
+    val payload = byteArrayOf(0x84.toByte()) + signature.toU8aV2() + method.toU8aV2()
+    return payload.size.toCompactU8a() + payload
+}
+
+fun ExtrinsicSignature.toU8aV2(): ByteArray {
+    if (signer.type != AddressType.AccountID) {
+        throw ScaleEncoderException("address type not supported")
+    }
+
+    return byteArrayOf(0xff.toByte()) +
+            (signer as AccountIDAddress).pubkey +
+            signature.toU8a() +
+            era.toU8a() +
+            nonce.toCompactU8a() +
+            tip.toCompactU8a()
+}
+
+fun ExtrinsicPayload.toU8aV2(): ByteArray {
+    return method.toU8aV2() +
+            era.toU8a() +
+            nonce.toCompactU8a() +
+            tip.toCompactU8a() +
+            specVersion.toInt().toU8a() +
+            transactionVersion.toInt().toU8a() +
+            genesisHash +
+            blockHash
+}

--- a/substrate-client/src/main/java/io/nodle/substratesdk/types/Extrinsic.kt
+++ b/substrate-client/src/main/java/io/nodle/substratesdk/types/Extrinsic.kt
@@ -1,9 +1,5 @@
 package io.nodle.substratesdk.types
 
-import io.nodle.substratesdk.account.signMsg
-import io.nodle.substratesdk.scale.toU8a
-import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters
-import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters
 import java.math.BigInteger
 
 /**
@@ -15,14 +11,14 @@ data class Extrinsic(
 )
 
 data class ExtrinsicSignature(
-    val signer: Ed25519PublicKeyParameters,
+    val signer: MultiAddress,
     val signature: ExtrinsicEd25519Signature,
     val era: ExtrinsicEra,
     val nonce: Long,
     val tip: BigInteger
 )
 
-data class ExtrinsicEd25519Signature(val ed25519: ByteArray)
+data class ExtrinsicEd25519Signature(val signature: ByteArray)
 
 abstract class ExtrinsicEra
 

--- a/substrate-client/src/main/java/io/nodle/substratesdk/types/MultiAddress.kt
+++ b/substrate-client/src/main/java/io/nodle/substratesdk/types/MultiAddress.kt
@@ -1,5 +1,7 @@
 package io.nodle.substratesdk.types
 
+import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters
+
 /**
  * @author Lucien Loiseau on 09/04/21.
  */
@@ -19,7 +21,9 @@ abstract class MultiAddress(val type: AddressType)
 
 // public key
 class AccountIDAddress(val pubkey: ByteArray) :
-    MultiAddress(AddressType.AccountID)
+    MultiAddress(AddressType.AccountID) {
+    constructor(ed: Ed25519PublicKeyParameters) : this(ed.encoded)
+}
 
 // encoded string
 class RawAddress(val bytes: ByteArray) : MultiAddress(AddressType.Raw)

--- a/substrate-client/src/main/java/io/nodle/substratesdk/types/MultiAddress.kt
+++ b/substrate-client/src/main/java/io/nodle/substratesdk/types/MultiAddress.kt
@@ -1,0 +1,41 @@
+package io.nodle.substratesdk.types
+
+/**
+ * @author Lucien Loiseau on 09/04/21.
+ */
+
+/**
+ * Represents the MultiAddress enum defined in Substrate
+ *
+ * See:
+ *   - https://github.com/paritytech/substrate/blob/master/primitives/runtime/src/multiaddress.rs
+ *   - https://github.com/paritytech/substrate/pull/7380
+ */
+enum class AddressType(val id: Int) {
+    AccountID(0), AccountIndex(1), Raw(2), Address32(3), Address20(4)
+}
+
+abstract class MultiAddress(val type: AddressType)
+
+// public key
+class AccountIDAddress(val pubkey: ByteArray) :
+    MultiAddress(AddressType.AccountID)
+
+// encoded string
+class RawAddress(val bytes: ByteArray) : MultiAddress(AddressType.Raw)
+
+// eth
+class Address20(val bytes: ByteArray) :
+    MultiAddress(AddressType.Address20) {
+    init {
+        require(bytes.size == 20)
+    }
+}
+
+// like a 256 bits hash
+class Address32(val bytes: ByteArray) :
+    MultiAddress(AddressType.Address32) {
+    init {
+        require(bytes.size == 32)
+    }
+}

--- a/substrate-client/src/test/java/io/nodle/substratesdk/TestEd25519.kt
+++ b/substrate-client/src/test/java/io/nodle/substratesdk/TestEd25519.kt
@@ -2,7 +2,9 @@ package io.nodle.substratesdk
 
 import io.nodle.substratesdk.account.Wallet
 import io.nodle.substratesdk.account.signMsg
+import io.nodle.substratesdk.utils.hexToBa
 import io.nodle.substratesdk.utils.toHex
+import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters
 import org.hamcrest.CoreMatchers
 import org.junit.Assert
 import org.junit.FixMethodOrder
@@ -15,7 +17,6 @@ import org.junit.runners.MethodSorters
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 class TestEd25519 {
-
     @Test
     fun stage0_testSigner() {
         val wallet = Wallet("void come effort suffer camp survey warrior heavy shoot primary clutch crush open amazing screen patrol group space point ten exist slush involve unfold")
@@ -23,4 +24,10 @@ class TestEd25519 {
         Assert.assertThat(signature.toHex(), CoreMatchers.equalTo("4e69456ddb02d48b6aec237ca844d83ad39be9e0778ac88472c7dd036a360c31ca17acf19197427c97ce58f9ba6311b409425d4e5c785e81edb733ca9208ad02"))
     }
 
+    @Test
+    fun stage1_testSigner() {
+        val wallet = Wallet(Ed25519PrivateKeyParameters("e0dab57d0f865f5add6121cc0d4351ac5eae7f66d7f371bf39d30b7ae913d2c4".hexToBa(), 0))
+        val signature = wallet.privateKey.signMsg("0300ffe432904cb94fdf27c6fdaad7985391f7bbe578e2df5ae1a6788bb07b5d6f15cf280048002d00000003000000f18113a0061d72db857d3b3e2f261e1c214989d191fa57380e633cc5c1a2ad38f18113a0061d72db857d3b3e2f261e1c214989d191fa57380e633cc5c1a2ad38".hexToBa())
+        Assert.assertThat(signature.toHex(), CoreMatchers.equalTo("2f0fada4259e8faf06806d0d56e72a0fb592f8923407f46637f4edd3e13b80082e75b22615059707d9523baf7ed706249c89ef518c0ff06912b654101385990f"))
+    }
 }

--- a/substrate-client/src/test/java/io/nodle/substratesdk/TestRpc.kt
+++ b/substrate-client/src/test/java/io/nodle/substratesdk/TestRpc.kt
@@ -1,11 +1,8 @@
 package io.nodle.substratesdk
 
 import com.github.doyaaaaaken.kotlincsv.dsl.csvReader
-import io.nodle.substratesdk.account.Account
 import io.nodle.substratesdk.account.Wallet
 import io.nodle.substratesdk.rpc.SubstrateProvider
-import io.nodle.substratesdk.scale.toU8a
-import io.nodle.substratesdk.utils.toHex
 import io.reactivex.rxjava3.kotlin.subscribeBy
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
@@ -16,7 +13,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.MethodSorters
 import org.mockserver.client.server.MockServerClient
-import org.mockserver.integration.ClientAndServer
 
 /**
  * @author Lucien Loiseau on 31/05/20.


### PR DESCRIPTION
this PR patches the substrate client to support Substrate 3.0

- implements the new MultiAddress type
- update the Extrinsic scale encoding to use MultiAddress
- backport the library for substrate 2.0
